### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/_layouts/devops.html
+++ b/_layouts/devops.html
@@ -152,8 +152,19 @@
         document.getElementById('team-name-display').textContent = teamName;
 
         const projectLink = document.getElementById('project-link');
-        projectLink.href = projectUrl;
-        projectLink.textContent = 'View Project';
+        try {
+            const url = new URL(projectUrl);
+            if (url.protocol === 'http:' || url.protocol === 'https:') {
+                projectLink.href = projectUrl;
+                projectLink.textContent = 'View Project';
+            } else {
+                throw new Error('Invalid protocol');
+            }
+        } catch (error) {
+            console.error('Invalid project URL:', error);
+            projectLink.href = '#';
+            projectLink.textContent = 'Invalid Project URL';
+        }
 
         const backlogLink = document.getElementById('backlog-link');
         const backlogLinkSeparator = document.getElementById('backlog-link-separator');


### PR DESCRIPTION
Potential fix for [https://github.com/mat-0/Tools.TheChels.uk/security/code-scanning/8](https://github.com/mat-0/Tools.TheChels.uk/security/code-scanning/8)

To fix the issue, we need to validate and sanitize the `projectUrl` value before assigning it to the `href` attribute. A simple and effective approach is to ensure that the URL is a valid and safe HTTP or HTTPS URL. This can be achieved using the `URL` constructor, which throws an error for invalid URLs. Additionally, we can check the protocol of the URL to ensure it is either `http:` or `https:`.

The changes will be made in the JavaScript code block where the `projectUrl` is assigned to the `href` attribute of the `projectLink` element. Specifically, we will validate the `projectUrl` value before using it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
