### PR TITLE
Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/_layouts/writing-style.html
+++ b/_layouts/writing-style.html
@@ -178,6 +178,12 @@
       return results;
     }
 
+    function escapeHTML(str) {
+      const div = document.createElement('div');
+      div.textContent = str;
+      return div.innerHTML;
+    }
+
     function displayResults(weasels, passives, duplicates) {
       const resultsDiv = document.getElementById('results');
       resultsDiv.innerHTML = '';
@@ -190,7 +196,7 @@
     ${weasels.length === 0 ? 'No weasel words found.' :
           weasels.map(w => `
         <div class="warning">
-          Found "<span class="highlight">${w.word}</span>" in: "${w.context}"
+          Found "<span class="highlight">${escapeHTML(w.word)}</span>" in: "${escapeHTML(w.context)}"
         </div>
       `).join('')}
   `;
@@ -218,7 +224,7 @@
     ${duplicates.length === 0 ? 'No duplicate words found.' :
           duplicates.map(d => `
         <div class="warning">
-          Found duplicate word "<span class="highlight">${d.word}</span>" in: "${d.context}"
+          Found duplicate word "<span class="highlight">${escapeHTML(d.word)}</span>" in: "${escapeHTML(d.context)}"
         </div>
       `).join('')}
   `;


### PR DESCRIPTION
Potential fix for [https://github.com/mat-0/Tools.TheChels.uk/security/code-scanning/12](https://github.com/mat-0/Tools.TheChels.uk/security/code-scanning/12)

To fix the issue, we need to ensure that any user input rendered into the DOM is properly escaped to prevent it from being interpreted as HTML. This can be achieved by using a function to escape special HTML characters (`<`, `>`, `&`, `"`, `'`) in the user input before rendering it. The fix involves:

1. Adding a helper function to escape HTML characters.
2. Using this helper function to sanitize the `context` and `word` values before they are inserted into the DOM.

The changes will be made in the `displayResults` function, specifically in the sections where `weasels`, `passives`, and `duplicates` are rendered.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
