### PR TITLE
Potential fix for code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/_layouts/writing-style.html
+++ b/_layouts/writing-style.html
@@ -210,7 +210,7 @@
     ${passives.length === 0 ? 'No passive voice constructions found.' :
           passives.map(p => `
         <div class="warning">
-          Found passive voice "<span class="highlight">${p.construction}</span>" in: "${p.context}"
+          Found passive voice "<span class="highlight">${escapeHTML(p.construction)}</span>" in: "${escapeHTML(p.context)}"
         </div>
       `).join('')}
   `;


### PR DESCRIPTION
Potential fix for [https://github.com/mat-0/Tools.TheChels.uk/security/code-scanning/11](https://github.com/mat-0/Tools.TheChels.uk/security/code-scanning/11)

To fix the issue, we need to ensure that all user-provided or derived data rendered into the DOM is properly escaped. Specifically, the `context` property of the `passives` array should be sanitized using the existing `escapeHTML` function before being included in the template literal on line 213. This will prevent any malicious input from being interpreted as HTML or JavaScript.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
