### PR TITLE
Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/_layouts/devops.html
+++ b/_layouts/devops.html
@@ -170,10 +170,23 @@
         const backlogLinkSeparator = document.getElementById('backlog-link-separator');
 
         if (backlogUrl) {
-            backlogLink.href = backlogUrl;
-            backlogLink.textContent = 'View Backlog';
-            backlogLink.style.display = 'inline';
-            backlogLinkSeparator.style.display = 'inline';
+            try {
+                const url = new URL(backlogUrl);
+                if (url.protocol === 'http:' || url.protocol === 'https:') {
+                    backlogLink.href = backlogUrl;
+                    backlogLink.textContent = 'View Backlog';
+                    backlogLink.style.display = 'inline';
+                    backlogLinkSeparator.style.display = 'inline';
+                } else {
+                    throw new Error('Invalid protocol');
+                }
+            } catch (error) {
+                console.error('Invalid backlog URL:', error);
+                backlogLink.href = '#';
+                backlogLink.textContent = 'Invalid Backlog URL';
+                backlogLink.style.display = 'inline';
+                backlogLinkSeparator.style.display = 'inline';
+            }
         } else {
             backlogLink.style.display = 'none';
             backlogLinkSeparator.style.display = 'none';


### PR DESCRIPTION
Potential fix for [https://github.com/mat-0/Tools.TheChels.uk/security/code-scanning/9](https://github.com/mat-0/Tools.TheChels.uk/security/code-scanning/9)

To fix the issue, we need to validate and sanitize the `backlogUrl` before using it. Specifically:
1. Use the `URL` constructor to parse and validate the `backlogUrl`. This ensures that only valid URLs with acceptable protocols (`http:` or `https:`) are allowed.
2. If the URL is invalid or uses an unacceptable protocol, set the `backlogLink` to a safe fallback state (e.g., `#` with a "Invalid Backlog URL" message).
3. This approach ensures that no untrusted or malicious input is used in the `href` attribute.

The changes will be made in the JavaScript section of the file `_layouts/devops.html`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
